### PR TITLE
Fix non-Apple builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,10 @@ let package = Package(
             dependencies: ["MissedSwiftSQLite"]
         ),
         .target(
-            name: "MissedSwiftSQLite"
+            name: "MissedSwiftSQLite",
+            linkerSettings: [
+                .linkedLibrary("sqlite3")
+            ]
         ),
         .testTarget(
             name: "LSQLiteTests",

--- a/Sources/LSQLite/Database/Database+Open.swift
+++ b/Sources/LSQLite/Database/Database+Open.swift
@@ -51,11 +51,13 @@ extension Database {
         public static let sharedCache = Self(rawValue: SQLITE_OPEN_SHAREDCACHE)
         public static let privateCache = Self(rawValue: SQLITE_OPEN_PRIVATECACHE)
         public static let wal = Self(rawValue: SQLITE_OPEN_WAL)
+#if canImport(Darwin)
         public static let fileProtectionComplete = Self(rawValue: SQLITE_OPEN_FILEPROTECTION_COMPLETE)
         public static let fileProtectionCompleteUnlessOpen = Self(rawValue: SQLITE_OPEN_FILEPROTECTION_COMPLETEUNLESSOPEN)
         public static let fileProtectionCompleteUntilFirstUserAuthentication = Self(rawValue: SQLITE_OPEN_FILEPROTECTION_COMPLETEUNTILFIRSTUSERAUTHENTICATION)
         public static let fileProtectionNone = Self(rawValue: SQLITE_OPEN_FILEPROTECTION_NONE)
         public static let fileProtectionMask = Self(rawValue: SQLITE_OPEN_FILEPROTECTION_MASK)
+#endif
     }
 
     /// Opens a database connection at the given filename using the supplied flags.


### PR DESCRIPTION
## Summary
- guard Apple-specific SQLite file protection flags so non-Apple platforms compile
- link libsqlite3 for the C target to satisfy SQLite symbols

## Testing
- swift test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dd67e3c9c8322bd3d59419d1e2e5d)