### PR TITLE
Use MissedSwiftSQLite imports for SQLite symbols

### DIFF
--- a/Sources/LSQLite/Blob/Blob+Access.swift
+++ b/Sources/LSQLite/Blob/Blob+Access.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Blob {
     /// Size of this open BLOB in bytes.

--- a/Sources/LSQLite/Blob/Blob+Lifecycle.swift
+++ b/Sources/LSQLite/Blob/Blob+Lifecycle.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Blob {
     /// Moves this BLOB handle to a different row of the same table.

--- a/Sources/LSQLite/Context/Context+Aggregate.swift
+++ b/Sources/LSQLite/Context/Context+Aggregate.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Context {
     /// Provides per-aggregate state storage of the given size for this context.

--- a/Sources/LSQLite/Context/Context+Auxiliary.swift
+++ b/Sources/LSQLite/Context/Context+Auxiliary.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Context {
     /// Destructor invoked when SQLite frees auxiliary data attached to a function argument.

--- a/Sources/LSQLite/Context/Context+Database.swift
+++ b/Sources/LSQLite/Context/Context+Database.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Context {
     /// Returns the database connection associated with this function context.

--- a/Sources/LSQLite/Context/Context+UserData.swift
+++ b/Sources/LSQLite/Context/Context+UserData.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Context {
     /// Retrieves the user data pointer supplied when the function was registered.

--- a/Sources/LSQLite/Database/Database+Authorizer.swift
+++ b/Sources/LSQLite/Database/Database+Authorizer.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// Authorization callback invoked during statement compilation.

--- a/Sources/LSQLite/Database/Database+Autocommit.swift
+++ b/Sources/LSQLite/Database/Database+Autocommit.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// Indicates whether this connection is currently in autocommit mode (no transaction open).

--- a/Sources/LSQLite/Database/Database+Blob.swift
+++ b/Sources/LSQLite/Database/Database+Blob.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// Access flags for incremental BLOB I/O opened via `openBlob(_:databaseName:tableName:columnName:rowID:flags:)`.

--- a/Sources/LSQLite/Database/Database+Busy.swift
+++ b/Sources/LSQLite/Database/Database+Busy.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// Callback invoked when SQLite reports a busy contention; return a retry decision.

--- a/Sources/LSQLite/Database/Database+Changes.swift
+++ b/Sources/LSQLite/Database/Database+Changes.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// Number of rows changed by the most recent INSERT, UPDATE, or DELETE on this connection (excludes trigger side-effects).

--- a/Sources/LSQLite/Database/Database+Checkpoint.swift
+++ b/Sources/LSQLite/Database/Database+Checkpoint.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// WAL checkpoint modes used by `walCheckpoint(_:mode:frameCount:totalFrameCount:)` and auto-checkpointing.

--- a/Sources/LSQLite/Database/Database+Close.swift
+++ b/Sources/LSQLite/Database/Database+Close.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// Closes the connection immediately; fails with `.busy` if statements, blobs, or backups are still open.

--- a/Sources/LSQLite/Database/Database+Collation.swift
+++ b/Sources/LSQLite/Database/Database+Collation.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// Comparator used by SQLite to order text for a custom collation.

--- a/Sources/LSQLite/Database/Database+Error.swift
+++ b/Sources/LSQLite/Database/Database+Error.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// Switch controlling whether extended result codes are reported for this connection.

--- a/Sources/LSQLite/Database/Database+Exec.swift
+++ b/Sources/LSQLite/Database/Database+Exec.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// Row callback invoked by `exec(_:)` when SQL produces result rows.

--- a/Sources/LSQLite/Database/Database+Filename.swift
+++ b/Sources/LSQLite/Database/Database+Filename.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// Returns the absolute filename for the named database on this connection.

--- a/Sources/LSQLite/Database/Database+Function.swift
+++ b/Sources/LSQLite/Database/Database+Function.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// C callback invoked to compute a scalar SQL function result.

--- a/Sources/LSQLite/Database/Database+Hooks.swift
+++ b/Sources/LSQLite/Database/Database+Hooks.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// Commit hook invoked before the transaction is finalized; return nonzero to roll back.

--- a/Sources/LSQLite/Database/Database+Interrupt.swift
+++ b/Sources/LSQLite/Database/Database+Interrupt.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// Requests that all running statements on this connection abort with `SQLITE_INTERRUPT`.

--- a/Sources/LSQLite/Database/Database+LastInsertRowid.swift
+++ b/Sources/LSQLite/Database/Database+LastInsertRowid.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// Rowid of the most recent successful INSERT on this connection (rowid tables only).

--- a/Sources/LSQLite/Database/Database+Limit.swift
+++ b/Sources/LSQLite/Database/Database+Limit.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// Runtime limit categories used with `Database.limit(for:)` and `Database.setLimit(_:for:)`.

--- a/Sources/LSQLite/Database/Database+Open.swift
+++ b/Sources/LSQLite/Database/Database+Open.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// SQLite filename wrapper used when opening a connection.

--- a/Sources/LSQLite/Database/Database+ProgressHandler.swift
+++ b/Sources/LSQLite/Database/Database+ProgressHandler.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// Callback invoked periodically during virtual machine execution; return a code indicating whether to continue.

--- a/Sources/LSQLite/Database/Database+Readonly.swift
+++ b/Sources/LSQLite/Database/Database+Readonly.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// Read/write state values returned by `readWriteAccessState(forDatabaseNamed:)`.

--- a/Sources/LSQLite/Database/Database+Statement.swift
+++ b/Sources/LSQLite/Database/Database+Statement.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Database {
     /// Returns the next prepared statement on this connection after the given one, or the first when `statement` is `nil`.

--- a/Sources/LSQLite/Database/Database+Trace.swift
+++ b/Sources/LSQLite/Database/Database+Trace.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 @available(iOS 10.0, macOS 10.12, tvOS 10.0, watchOS 3.0, *)
 extension Database {

--- a/Sources/LSQLite/Datatype.swift
+++ b/Sources/LSQLite/Datatype.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 /// Swift wrapper around SQLite's fundamental datatype codes used in value and column inspection.
 ///

--- a/Sources/LSQLite/Statement/Statement+Busy.swift
+++ b/Sources/LSQLite/Statement/Statement+Busy.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Statement {
     /// True if the statement has been stepped and not yet finished or reset.

--- a/Sources/LSQLite/Statement/Statement+Column.swift
+++ b/Sources/LSQLite/Statement/Statement+Column.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Statement {
     /// Number of columns in the result set.

--- a/Sources/LSQLite/Statement/Statement+Database.swift
+++ b/Sources/LSQLite/Statement/Statement+Database.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Statement {
     /// Database connection that owns this prepared statement.

--- a/Sources/LSQLite/Statement/Statement+Finalize.swift
+++ b/Sources/LSQLite/Statement/Statement+Finalize.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Statement {
     /// Finalizes and destroys the prepared statement handle.

--- a/Sources/LSQLite/Statement/Statement+Prepare.swift
+++ b/Sources/LSQLite/Statement/Statement+Prepare.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Statement {
     /// Flags for sqlite3_prepare_v3 prepFlags argument.

--- a/Sources/LSQLite/Statement/Statement+Readonly.swift
+++ b/Sources/LSQLite/Statement/Statement+Readonly.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Statement {
     /// True if the prepared statement does not directly modify the database.

--- a/Sources/LSQLite/Statement/Statement+Reset.swift
+++ b/Sources/LSQLite/Statement/Statement+Reset.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Statement {
     /// Resets the prepared statement to run again from the beginning.

--- a/Sources/LSQLite/Statement/Statement+SQL.swift
+++ b/Sources/LSQLite/Statement/Statement+SQL.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Statement {
     /// Original SQL text used to create the statement.

--- a/Sources/LSQLite/Statement/Statement+Step.swift
+++ b/Sources/LSQLite/Statement/Statement+Step.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Statement {
     /// Steps the prepared statement once, returning the SQLite result code (row, done, or error).

--- a/Sources/LSQLite/Value/Value+Getters.swift
+++ b/Sources/LSQLite/Value/Value+Getters.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Value {
     /// Pointer to the BLOB bytes for this value, or nil if not a BLOB.

--- a/Sources/LSQLite/Value/Value+Introspect.swift
+++ b/Sources/LSQLite/Value/Value+Introspect.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 extension Value {
     /// Number of bytes in the value for BLOB or text; 0 for other types.

--- a/Sources/LSQLite/Value/Value+Memory.swift
+++ b/Sources/LSQLite/Value/Value+Memory.swift
@@ -1,4 +1,4 @@
-import SQLite3
+import MissedSwiftSQLite
 
 @available(iOS 10.0, macOS 10.12, tvOS 10.0, watchOS 3.0, *)
 extension Value {


### PR DESCRIPTION
### Motivation
- Ensure the project imports the `MissedSwiftSQLite` module instead of the platform `SQLite3` to improve Linux and cross-platform availability.
- Avoid build issues on Linux where `SQLite3` may not be available as a Swift module.
- Keep the existing SQLite C symbols accessible while switching to a portable module name.

### Description
- Replaced all occurrences of `import SQLite3` with `import MissedSwiftSQLite` across LSQLite sources in `Sources/LSQLite`.
- Applied the import swap to approximately 40 source files so existing calls to `sqlite3_*` functions remain unchanged.
- No other API or behavioral changes were made beyond the import replacement.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e87f59ac483229042ffb230c0b428)